### PR TITLE
Change FilterRegister to implement ServletContextListener instead of ServletContextAware

### DIFF
--- a/omod/src/main/java/org/openmrs/module/datafilter/web/DataFilterWebComponentRegistrar.java
+++ b/omod/src/main/java/org/openmrs/module/datafilter/web/DataFilterWebComponentRegistrar.java
@@ -17,22 +17,27 @@ import java.util.EnumSet;
 
 import javax.servlet.FilterRegistration;
 import javax.servlet.ServletContext;
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
 
 import org.springframework.stereotype.Component;
-import org.springframework.web.context.ServletContextAware;
 
 /**
  * Registers web components that typically are registered via web.xml e.g. filters, servlets and
  * listeners.
  */
 @Component
-public class DataFilterWebComponentRegistrar implements ServletContextAware {
-	
+public class DataFilterWebComponentRegistrar implements ServletContextListener {
 	@Override
-	public void setServletContext(ServletContext servletContext) {
+	public void contextInitialized(ServletContextEvent servletContextEvent) {
+		ServletContext servletContext = servletContextEvent.getServletContext();
 		FilterRegistration filterReg = servletContext.addFilter("datafilter-Filter", new DataFilterWebFilter());
 		//TODO Should ignore static content requests
 		filterReg.addMappingForUrlPatterns(EnumSet.of(ERROR, FORWARD, REQUEST), true, "/*");
 	}
-	
+
+	@Override
+	public void contextDestroyed(ServletContextEvent servletContextEvent) {
+
+	}
 }


### PR DESCRIPTION
### Context:
As part of one of the [this commit](https://github.com/openmrs/openmrs-module-datafilter/commit/7cf2aa170bc0020fed927d010b366c623f5a86b2), we have introduced a `DataFilterWebComponentRegistrar ` which adds `data-filter` to the `servlet-context`.

### Problem:
Right now, the application gives an error while starting up as below:
```
Error creating bean with name 'dataFilterWebComponentRegistrar' 
defined in URL [jar:file:/usr/local/tomcat/.OpenMRS/.openmrs-lib-cache/datafilter/datafilter.jar!/org/openmrs/module/datafilter/web/DataFilterWebComponentRegistrar.class]: 
Initialization of bean failed; nested exception is java.lang.IllegalStateException: Filters can not be added to context /openmrs as the context has been initialised
```
Following this below error is coming multiple times:
```
org.hibernate.service.UnknownServiceException: Unknown service requested [org.hibernate.engine.jdbc.connections.spi.ConnectionProvider]
```

### Possible Cause:
This `DataFilterWebComponentRegistrar ` implements the `ServletContextAware` which gives a method `setServletCotext`. It passes the current `servletContext` to this method to which we are trying to add the filter.
[From the docs of setServerletCotext](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/context/ServletContextAware.html#setServletContext-javax.servlet.ServletContext-) :
>Invoked after population of normal bean properties but before an init callback like InitializingBean's afterPropertiesSet or a custom init-method. **Invoked after ApplicationContextAware's setApplicationContext**.

From the above line, it looks like we would be adding filters after the context has been initialized. That would cause the above startup issue.

### Possible Fix (included in PR):
After some research, I found out that we could change the `DataFilterWebComponentRegistrar` to implement the `ServeletContextListener`. We can add the filter in [contextInitialized](https://docs.oracle.com/javaee/6/api/javax/servlet/ServletContextListener.html#contextInitialized%28javax.servlet.ServletContextEvent%29) method, which passes the ServletContext while initialization is in progress.
From the docs above:
>Parameters:
sce - the ServletContextEvent containing the ServletContext that is being initialized

### Verification
After these changes, the server startup error is gone, but I couldn't verify the expected filter behavior.
