### PR TITLE
Failing test for bypass encounter privilege

### DIFF
--- a/api/src/test/java/org/openmrs/module/datafilter/impl/ImplDataFilterInterceptorTest.java
+++ b/api/src/test/java/org/openmrs/module/datafilter/impl/ImplDataFilterInterceptorTest.java
@@ -163,7 +163,30 @@ public class ImplDataFilterInterceptorTest {
 		interceptor.onLoad(new Encounter(), encounterId, new Object[] { encType }, new String[] { "encounterType" },
 		    new Type[] { new ManyToOneType(null, null) });
 	}
-	
+
+	@Test
+	public void shouldByPass_whenLoggedInUser_hasEncounterBypassPrivilegeButNotSpecificEncounterViewPrivilege() {
+		final Integer userId = 3;
+		final Integer encounterId = 987;
+		User user = mock(User.class);
+		user.setId(userId);
+
+		when(Context.getAuthenticatedUser()).thenReturn(user);
+		when(Util.isFilterDisabled("datafilter_locationBasedEncounterFilter")).thenReturn(true);
+
+		final String encounterViewPrivilege = "Specific Encounter View Privilege";
+		final Integer encounterTypeId = 32;
+		when(AccessUtil.getViewPrivilege(Matchers.eq(encounterTypeId))).thenReturn(encounterViewPrivilege);
+		when(user.hasPrivilege(Matchers.eq(encounterViewPrivilege))).thenReturn(false);
+
+		when(user.hasPrivilege("datafilter_encTypePrivBasedEncounterFilter" + DataFilterConstants.BYPASS_PRIV_SUFFIX)).thenReturn(true);
+
+		EncounterType encType = new EncounterType();
+		encType.setId(encounterTypeId);
+		interceptor.onLoad(new Encounter(), encounterId, new Object[] { encType }, new String[] { "encounterType" },
+				new Type[] { new ManyToOneType(null, null) });
+	}
+
 	@Test
 	public void onLoad_shouldPassIfAllEncounterTypeViewPrivilegeBasedFiltersAreDisabled() throws Exception {
 		User user = mock(User.class);


### PR DESCRIPTION
When a logged in user has bypass encounter privilege like `datafilter_encTypePrivBasedEncounterFilter_ByPass` and does not have access to specific encounter view access we get the below error 

```
org.openmrs.api.context.ContextAuthenticationException: Illegal Record Access
	at org.openmrs.module.datafilter.impl.ImplDataFilterInterceptor.checkIfHasEncounterTypeBasedAccess(ImplDataFilterInterceptor.java:176)
```

There is a failing test replicating the scenario. 

The expectation was that when the user has bypass privilege it would not check the specific privilege for logged in user in in the [checkIfHasEncounterTypeBasedAccess method](https://github.com/openmrs/openmrs-module-datafilter/blob/master/api/src/main/java/org/openmrs/module/datafilter/impl/ImplDataFilterInterceptor.java#L145-L180)