### PR TITLE
FILTER-4: Implement data filter UI using extension point

### DIFF
--- a/api/src/main/java/org/openmrs/module/datafilter/impl/api/DataFilterService.java
+++ b/api/src/main/java/org/openmrs/module/datafilter/impl/api/DataFilterService.java
@@ -13,6 +13,7 @@ import java.util.Collection;
 
 import org.openmrs.OpenmrsObject;
 import org.openmrs.api.OpenmrsService;
+import org.openmrs.module.datafilter.impl.EntityBasisMap;
 
 public interface DataFilterService extends OpenmrsService {
 	
@@ -56,5 +57,8 @@ public interface DataFilterService extends OpenmrsService {
 	 * @return true if the entity has access otherwise false
 	 */
 	boolean hasAccess(OpenmrsObject entity, OpenmrsObject basis);
+
+
+	Collection<EntityBasisMap> get(OpenmrsObject entity, String basisName);
 	
 }

--- a/api/src/main/java/org/openmrs/module/datafilter/impl/api/db/DataFilterDAO.java
+++ b/api/src/main/java/org/openmrs/module/datafilter/impl/api/db/DataFilterDAO.java
@@ -11,6 +11,8 @@ package org.openmrs.module.datafilter.impl.api.db;
 
 import org.openmrs.module.datafilter.impl.EntityBasisMap;
 
+import java.util.Collection;
+
 public interface DataFilterDAO {
 	
 	/**
@@ -37,5 +39,13 @@ public interface DataFilterDAO {
 	 * @param entityBasisMap
 	 */
 	void deleteEntityBasisMap(EntityBasisMap entityBasisMap);
-	
+
+	/**
+	 * Get all the EntityBasisMap for the specified entity and type from the database
+	 *
+	 * @param entityIdentifier
+	 * @param entityType
+	 * @param basisType
+	 */
+	Collection<EntityBasisMap> get(String entityIdentifier, String entityType, String basisType);
 }

--- a/api/src/main/java/org/openmrs/module/datafilter/impl/api/db/hibernate/HibernateDataFilterDAO.java
+++ b/api/src/main/java/org/openmrs/module/datafilter/impl/api/db/hibernate/HibernateDataFilterDAO.java
@@ -15,6 +15,8 @@ import org.hibernate.criterion.Restrictions;
 import org.openmrs.module.datafilter.impl.EntityBasisMap;
 import org.openmrs.module.datafilter.impl.api.db.DataFilterDAO;
 
+import java.util.Collection;
+
 public class HibernateDataFilterDAO implements DataFilterDAO {
 	
 	private SessionFactory sessionFactory;
@@ -52,7 +54,7 @@ public class HibernateDataFilterDAO implements DataFilterDAO {
 		sessionFactory.getCurrentSession().save(entityBasisMap);
 		return entityBasisMap;
 	}
-	
+
 	/**
 	 * @see DataFilterDAO#deleteEntityBasisMap(EntityBasisMap)
 	 */
@@ -60,5 +62,14 @@ public class HibernateDataFilterDAO implements DataFilterDAO {
 	public void deleteEntityBasisMap(EntityBasisMap entityBasisMap) {
 		sessionFactory.getCurrentSession().delete(entityBasisMap);
 	}
-	
+
+    @Override
+    public Collection<EntityBasisMap> get(String entityIdentifier, String entityType, String basisType) {
+        Criteria criteria = sessionFactory.getCurrentSession().createCriteria(EntityBasisMap.class);
+        criteria.add(Restrictions.eq("entityIdentifier", entityIdentifier).ignoreCase());
+        criteria.add(Restrictions.eq("entityType", entityType).ignoreCase());
+        criteria.add(Restrictions.eq("basisType", basisType).ignoreCase());
+
+        return (Collection<EntityBasisMap>) criteria.list();
+    }
 }

--- a/api/src/main/java/org/openmrs/module/datafilter/impl/api/impl/DataFilterServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/datafilter/impl/api/impl/DataFilterServiceImpl.java
@@ -128,5 +128,9 @@ public class DataFilterServiceImpl extends BaseOpenmrsService implements DataFil
 		
 		return entityId;
 	}
-	
+
+	@Override
+	public Collection<EntityBasisMap> get(OpenmrsObject entity, String basis) {
+		return dao.get(entity.getId().toString(),entity.getClass().getName(),basis);
+	}
 }

--- a/api/src/test/java/org/openmrs/module/datafilter/impl/api/DataFilterServiceTest.java
+++ b/api/src/test/java/org/openmrs/module/datafilter/impl/api/DataFilterServiceTest.java
@@ -18,6 +18,7 @@ import java.util.Collection;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.openmrs.Location;
@@ -27,6 +28,7 @@ import org.openmrs.User;
 import org.openmrs.module.datafilter.DataFilterSessionContext;
 import org.openmrs.module.datafilter.TestConstants;
 import org.openmrs.module.datafilter.impl.BaseFilterTest;
+import org.openmrs.module.datafilter.impl.EntityBasisMap;
 import org.powermock.reflect.Whitebox;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -109,5 +111,11 @@ public class DataFilterServiceTest extends BaseFilterTest {
 			assertFalse(service.hasAccess(user, basis));
 		}
 	}
-	
+
+	@Test
+	public void get_shouldGetAllEntityBasisForAnEntityForABasisType(){
+		User user = new User(3000);
+		Collection<EntityBasisMap> map = service.get(user,Location.class.getName());
+		Assert.assertEquals(2,map.size());
+	}
 }

--- a/omod/src/main/java/org/openmrs/module/datafilter/extension/html/Content.java
+++ b/omod/src/main/java/org/openmrs/module/datafilter/extension/html/Content.java
@@ -1,0 +1,64 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+
+package org.openmrs.module.datafilter.extension.html;
+
+import java.util.List;
+
+public class Content {
+
+    private final List<String> locationNames;
+    private final List<String> selectedLocations;
+    private String styles;
+    private String scripts;
+    private String title;
+    private String contentStart;
+    private String contentEnd;
+    private static final String CHECKED = " checked";
+
+    public Content(List<String> locationNames, List<String> selectedLocations) {
+        this.locationNames = locationNames;
+        this.selectedLocations = selectedLocations;
+        this.styles = "<style>.listItemBoxCustom {width: 460px;" +
+                "padding: 2px;" +
+                "border: 1px solid lightgray;" +
+                "float: left;" +
+                "background-color: #EFEFEF;" +
+                "overflow-x: scroll;" +
+                "height: 200px;}" +
+                "</style>";
+        this.scripts = "";
+        this.title = "Location";
+        this.contentStart = styles + scripts +
+                "<td valign='top'>" + title + "</td>" +
+                "<p>Selected Locations:</p>" + "<p id='selectedLocations'></p>" +
+                "<td valign='top'>" +
+                "<div id='locationStrings' class='listItemBoxCustom'>";
+        this.contentEnd = "</div></td>";
+    }
+
+    public String generate() {
+        return contentStart + addHTMLForLocationNames() + contentEnd;
+    }
+
+    private String addHTMLForLocationNames() {
+        return locationNames.stream().reduce("", (appendedContent, locationName) -> {
+            String checkedValue = "";
+            appendedContent += "<span class='listItem'>";
+            if (selectedLocations.contains(locationName)) {
+                checkedValue = CHECKED;
+            }
+            appendedContent += "<input type='checkbox' name='locationStrings' id='locationStrings." + locationName + "'" + " value='" + locationName + "'" + checkedValue + ">";
+            appendedContent += "<label for='locationStrings." + locationName + "'>" + locationName + "</label>";
+            appendedContent += "</span>";
+            return appendedContent;
+        });
+    }
+}

--- a/omod/src/main/java/org/openmrs/module/datafilter/extension/html/LocationExt.java
+++ b/omod/src/main/java/org/openmrs/module/datafilter/extension/html/LocationExt.java
@@ -1,0 +1,73 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+
+package org.openmrs.module.datafilter.extension.html;
+
+import org.openmrs.Location;
+import org.openmrs.User;
+import org.openmrs.api.LocationService;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.Extension;
+import org.openmrs.module.datafilter.impl.EntityBasisMap;
+import org.openmrs.module.datafilter.impl.api.DataFilterService;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class LocationExt extends Extension {
+
+    String label = "";
+
+   public String getLabel() {
+        label = "Location";
+        return label;
+    }
+
+
+    /**
+     * Returns the required privilege in order to see this section. Can be a
+     * comma delimited list of privileges. If the default empty string is
+     * returned, only an authenticated user is required
+     *
+     * @return Privilege string
+     */
+
+    @Override
+    public String getOverrideContent(String bodyContent) {
+        List<Location> locations = Context.getLocationService().getAllLocations();
+
+        List<String> locationNames = locations.stream().map(location -> location.getName()).collect(Collectors.toList());
+        String userId = getParameterMap().get("userId");
+        List<String> selectedLocations = getMappedLocations(userId);
+        Content content = new Content(locationNames, selectedLocations);
+        return content.generate();
+    }
+
+    private List<String> getMappedLocations(String userId) {
+        DataFilterService dataFilterService = Context.getRegisteredComponents(DataFilterService.class).get(0);
+        LocationService locationService = Context.getLocationService();
+        List<String> selectedLocations = new ArrayList<>();
+        if (!userId.equals("")) {
+            User user = Context.getUserService().getUser(Integer.parseInt(userId));
+            Collection<EntityBasisMap> mappedLocationsMap = dataFilterService.get(user, Location.class.getName());
+            if (mappedLocationsMap != null) {
+                selectedLocations = mappedLocationsMap.stream().map(mappedLocation -> locationService.getLocation(Integer.parseInt(mappedLocation.getBasisIdentifier())).getName()).collect(Collectors.toList());
+            }
+        }
+        return selectedLocations;
+    }
+
+    @Override
+    public MEDIA_TYPE getMediaType() {
+        return MEDIA_TYPE.html;
+    }
+}

--- a/omod/src/main/java/org/openmrs/module/datafilter/filter/SubmissionFilter.java
+++ b/omod/src/main/java/org/openmrs/module/datafilter/filter/SubmissionFilter.java
@@ -1,0 +1,136 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.datafilter.filter;
+
+import org.apache.commons.lang.StringUtils;
+import org.openmrs.Location;
+import org.openmrs.OpenmrsObject;
+import org.openmrs.User;
+import org.openmrs.api.LocationService;
+import org.openmrs.api.UserService;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.datafilter.impl.EntityBasisMap;
+import org.openmrs.module.datafilter.impl.api.DataFilterService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.servlet.*;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class SubmissionFilter implements Filter {
+
+	private static final Logger log = LoggerFactory.getLogger(SubmissionFilter.class);
+
+	private DataFilterService dataFilterService;
+
+	private LocationService locationService;
+
+	private UserService userService;
+
+	public SubmissionFilter() {
+		this.dataFilterService = Context.getRegisteredComponents(DataFilterService.class).get(0);
+		this.locationService = Context.getLocationService();
+		this.userService = Context.getUserService();
+	}
+
+	/**
+	 * @see Filter#init(FilterConfig)
+	 */
+	@Override
+	public void init(FilterConfig filterConfig) {
+		if (log.isDebugEnabled()) {
+			log.debug("Initializing datafilter web filter....");
+		}
+	}
+
+	/**
+	 * @see Filter#doFilter(ServletRequest, ServletResponse, FilterChain)
+	 */
+	@Override
+	public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+			throws IOException, ServletException {
+
+		chain.doFilter(request, response);
+
+		if (((HttpServletRequest) request).getMethod().equals("POST") &&
+				((HttpServletResponse) response).getStatus() != 400) {
+
+			User user = null;
+			//TODO remove this if condition when the legacy ui passes userId
+			String userName = request.getParameter("username");
+			if (!StringUtils.isEmpty(userName)) {
+				user = userService.getUserByUsername(userName);
+			}
+
+			if (user == null) {
+				String userUUID = ((HttpServletResponse) response).getHeader("userUUID");
+				user = userService.getUserByUuid(userUUID);
+			}
+
+			if (user == null) {
+				log.info("User details missing or Invalid user details");
+				return;
+			}
+			String[] locationStrings = request.getParameterValues("locationStrings");
+			if (locationStrings == null) {
+				log.info("No locations selected");
+				return;
+			}
+			Set<OpenmrsObject> allSelectedLocations = Arrays.stream(locationStrings)
+					.map(l -> locationService.getLocation(l))
+					.filter(Objects::nonNull)
+					.collect(Collectors.toSet());
+
+			Collection<EntityBasisMap> mappedLocationsMap = dataFilterService.get(user, Location.class.getName());
+			List<OpenmrsObject> locationsToBeRevoked = getLocationsToBeRevoked(locationService.getAllLocations(),
+					mappedLocationsMap, locationStrings);
+			if (!locationsToBeRevoked.isEmpty()) {
+				dataFilterService.revokeAccess(user, locationsToBeRevoked);
+			}
+			if (!allSelectedLocations.isEmpty()) {
+				dataFilterService.grantAccess(user, allSelectedLocations);
+			}
+
+		}
+	}
+
+	/**
+	 * @see Filter#destroy()
+	 */
+	@Override
+	public void destroy() {
+		if (log.isDebugEnabled()) {
+			log.debug("Destroying datafilter web filter....");
+		}
+	}
+
+	private List<OpenmrsObject> getLocationsToBeRevoked(List<Location> allLocationsForLoggedInUser,
+			Collection<EntityBasisMap> entityBasisMapsForUserBeingEdited, String[] locationStrings) {
+
+		Set<String> mappedLocationIDsForUser = entityBasisMapsForUserBeingEdited.stream().map(
+				entityBasisMap -> entityBasisMap.getBasisIdentifier()).collect(Collectors.toSet());
+
+		List<String> markedLocations = Arrays.asList(locationStrings);
+
+		List<Location> locationsLoggedInUserHasControl = allLocationsForLoggedInUser.stream().filter(
+				(location) -> mappedLocationIDsForUser.contains(location.getLocationId().toString()))
+				.collect(Collectors.toList());
+
+		if (!locationsLoggedInUserHasControl.isEmpty()) {
+			return locationsLoggedInUserHasControl.stream().filter(location -> !markedLocations.contains(
+					location.getName())).collect(Collectors.toList());
+		}
+		return new ArrayList<>();
+	}
+}

--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -38,6 +38,16 @@
         <url-pattern>/*</url-pattern>
     </filter-mapping>
 
+    <filter>
+        <filter-name>org.openmrs.module.datafilter.filter.SubmissionFilter</filter-name>
+        <filter-class>org.openmrs.module.datafilter.filter.SubmissionFilter</filter-class>
+    </filter>
+
+    <filter-mapping>
+        <filter-name>org.openmrs.module.datafilter.filter.SubmissionFilter</filter-name>
+        <url-pattern>/admin/users/user.form</url-pattern>
+    </filter-mapping>
+
     <!-- Privileges
     <privilege>
         <name>ByPass Data Filters</name>
@@ -63,5 +73,9 @@
         </description>
     </globalProperty>
 
+    <extension>
+        <point>org.openmrs.userForm.custom.extension</point>
+        <class>org.openmrs.module.datafilter.extension.html.LocationExt</class>
+    </extension>
 </module>
 

--- a/omod/src/test/java/org/openmrs/module/datafilter/extension/html/ContentTest.java
+++ b/omod/src/test/java/org/openmrs/module/datafilter/extension/html/ContentTest.java
@@ -1,0 +1,72 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+
+package org.openmrs.module.datafilter.extension.html;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import static org.junit.Assert.assertEquals;
+
+public class ContentTest {
+
+    @Test
+    public void addLocationNameLine() {
+        Content content = new Content(Arrays.asList("L1","L2"),new ArrayList<String>());
+
+        String expected = "<style>.listItemBoxCustom {width: 460px;padding: 2px;border: 1px solid lightgray;float: left;background-color: #EFEFEF;overflow-x: scroll;height: 200px;}</style>" +
+                "<td valign='top'>Location</td>" +
+                "<p>Selected Locations:</p>" +
+                "<p id='selectedLocations'></p>" +
+                "<td valign='top'><div id='locationStrings' class='listItemBoxCustom'>" +
+                "<span class='listItem'>" +
+                "<input type='checkbox' name='locationStrings' id='locationStrings.L1' value='L1'><label for='locationStrings.L1'>L1</label>" +
+                "</span>" +
+                "<span class='listItem'>" +
+                "<input type='checkbox' name='locationStrings' id='locationStrings.L2' value='L2'><label for='locationStrings.L2'>L2</label>" +
+                "</span>" +
+                "</div></td>";
+        assertEquals(expected, content.generate());
+
+    }
+
+    @Test
+    public void addLocationNameLineWithMappedLocationsChecked() {
+        Content content = new Content(Arrays.asList("L1","L2"),Arrays.asList("L2"));
+
+        String expected = "<style>.listItemBoxCustom {width: 460px;padding: 2px;border: 1px solid lightgray;float: left;background-color: #EFEFEF;overflow-x: scroll;height: 200px;}</style>" +
+                "<td valign='top'>Location</td>" +
+                "<p>Selected Locations:</p>" +
+                "<p id='selectedLocations'></p>" +
+                "<td valign='top'><div id='locationStrings' class='listItemBoxCustom'>" +
+                "<span class='listItem'>" +
+                "<input type='checkbox' name='locationStrings' id='locationStrings.L1' value='L1'><label for='locationStrings.L1'>L1</label>" +
+                "</span>" +
+                "<span class='listItem'>" +
+                "<input type='checkbox' name='locationStrings' id='locationStrings.L2' value='L2' checked><label for='locationStrings.L2'>L2</label>" +
+                "</span>" +
+                "</div></td>";
+        assertEquals(expected, content.generate());
+
+    }
+
+    @Test
+    public void getFullContent() {
+        String expected = "<style>.listItemBoxCustom {width: 460px;padding: 2px;border: 1px solid lightgray;float: left;background-color: #EFEFEF;overflow-x: scroll;height: 200px;}</style>" +
+                "<td valign='top'>Location</td>" +
+                "<p>Selected Locations:</p>" +
+                "<p id='selectedLocations'></p>" +
+                "<td valign='top'><div id='locationStrings' class='listItemBoxCustom'></div></td>";
+        assertEquals(expected, new Content(new ArrayList<>(), new ArrayList<>()).generate());
+
+    }
+}

--- a/omod/src/test/java/org/openmrs/module/datafilter/filter/SubmissionFilterTest.java
+++ b/omod/src/test/java/org/openmrs/module/datafilter/filter/SubmissionFilterTest.java
@@ -1,0 +1,287 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.datafilter.filter;
+
+import org.hamcrest.collection.IsCollectionWithSize;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.*;
+import org.openmrs.Location;
+import org.openmrs.OpenmrsObject;
+import org.openmrs.User;
+import org.openmrs.api.LocationService;
+import org.openmrs.api.UserService;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.datafilter.impl.EntityBasisMap;
+import org.openmrs.module.datafilter.impl.api.DataFilterService;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import javax.servlet.FilterChain;
+import javax.servlet.RequestDispatcher;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.util.*;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+@PrepareForTest(Context.class)
+@RunWith(PowerMockRunner.class)
+@PowerMockIgnore("jdk.internal.reflect.*")
+public class SubmissionFilterTest {
+
+    @Mock
+    private FilterChain filterChain;
+
+    @Mock
+    private LocationService locationService;
+
+    @Mock
+    private DataFilterService dataFilterService;
+
+    @Mock
+    private UserService userService;
+
+    private SubmissionFilter submissionFilter;
+
+    private RequestDispatcher mockRequestDispatcher;
+
+    @Before
+    public void setUp() throws Exception {
+        initMocks(this);
+
+        PowerMockito.mockStatic(Context.class);
+        when(Context.getRegisteredComponents(DataFilterService.class))
+                .thenReturn(Arrays.asList(dataFilterService));
+        when(Context.getLocationService()).thenReturn(locationService);
+        when(Context.getUserService()).thenReturn(userService);
+
+        submissionFilter = new SubmissionFilter();
+        mockRequestDispatcher = Mockito.mock(RequestDispatcher.class);
+    }
+
+
+    @Test
+    public void shouldNotGrandAccessToUserIfNotPostRequest() throws Exception {
+        HttpServletRequest request = buildMockHttpServletRequest("GET","user_x",null);
+
+        MockHttpServletResponse response = buildMockHttpServletResponse();
+
+        submissionFilter.doFilter(request, response, filterChain);
+
+        verify(userService, never()).getUserByUsername(any(String.class));
+        verify(locationService, never()).getLocation(any(String.class));
+        verify(dataFilterService, never()).grantAccess(any(User.class), anyCollectionOf(OpenmrsObject.class));
+    }
+
+    @Test
+    public void shouldNotGrandAccessToUserIfResponseStatusIs400() throws Exception {
+        HttpServletRequest request = buildMockHttpServletRequest("POST","user_x",new String[]{"l1","l2"});
+
+        MockHttpServletResponse response = buildMockHttpServletResponse();
+        response.setStatus(400);
+
+        submissionFilter.doFilter(request, response, filterChain);
+
+        verify(userService, never()).getUserByUsername(any(String.class));
+        verify(locationService, never()).getLocation(any(String.class));
+        verify(dataFilterService, never()).grantAccess(any(User.class), anyCollectionOf(OpenmrsObject.class));
+    }
+
+    @Test
+    public void shouldNotGrandAccessToUserIfUserDetailsMissing() throws Exception {
+        HttpServletRequest request = buildMockHttpServletRequest("POST","",new String[]{"l1","l2"});
+
+        MockHttpServletResponse response = buildMockHttpServletResponse();
+
+        submissionFilter.doFilter(request, response, filterChain);
+
+        verify(userService, never()).getUserByUsername(any(String.class));
+        verify(locationService, never()).getLocation(any(String.class));
+        verify(dataFilterService, never()).grantAccess(any(User.class), anyCollectionOf(OpenmrsObject.class));
+    }
+
+    @Test
+    public void shouldNotGrandAccessIfUserIsNotValid() throws Exception {
+        HttpServletRequest request = buildMockHttpServletRequest("POST","invalid_user",new String[]{"l1","l2"});
+
+        MockHttpServletResponse response = buildMockHttpServletResponse();
+
+        when(userService.getUserByUsername(any(String.class))).thenReturn(null);
+        submissionFilter.doFilter(request, response, filterChain);
+
+        verify(userService).getUserByUsername(any(String.class));
+        verify(locationService, never()).getLocation(any(String.class));
+        verify(dataFilterService, never()).grantAccess(any(User.class), anyCollectionOf(OpenmrsObject.class));
+    }
+
+    @Test
+    public void shouldNotGrandAccessToUserIfLocationMissing() throws Exception {
+        HttpServletRequest request = buildMockHttpServletRequest("POST","invalid_user",new String[]{});
+        ((MockHttpServletRequest) request).setMethod("POST");
+        ((MockHttpServletRequest) request).addParameter("username", "user_x");
+
+        MockHttpServletResponse response = buildMockHttpServletResponse();
+
+        when(userService.getUserByUsername(any(String.class))).thenReturn(new User());
+        submissionFilter.doFilter(request, response, filterChain);
+
+        verify(userService).getUserByUsername(any(String.class));
+        verify(locationService, never()).getLocation(any(String.class));
+        verify(dataFilterService, never()).grantAccess(any(User.class), anyCollectionOf(OpenmrsObject.class));
+    }
+
+    @Test
+    public void shouldNotGrandAccessIfLocationIsNotValid() throws Exception {
+        HttpServletRequest request = buildMockHttpServletRequest("POST","user_x",new String[]{"invalid_1","invalid_2"});
+
+        MockHttpServletResponse response = buildMockHttpServletResponse();
+
+        User user = new User();
+        when(locationService.getLocation(any(String.class))).thenReturn(null);
+        when(userService.getUserByUsername(any(String.class))).thenReturn(user);
+
+        submissionFilter.doFilter(request, response, filterChain);
+
+        verify(dataFilterService, never()).grantAccess(any(User.class), anyCollectionOf(OpenmrsObject.class));
+    }
+
+    @Test
+    public void shouldGrandAccessToUser() throws Exception {
+
+        HttpServletRequest request = buildMockHttpServletRequest("POST","user_x",new String[]{"l1","l2"});
+
+        MockHttpServletResponse response = buildMockHttpServletResponse();
+
+        User user = new User();
+        when(locationService.getAllLocations()).thenReturn(getLocations(Arrays.asList("l1","l2","l3")));
+        when(locationService.getLocation("l1")).thenReturn(getLocation( "l1"));
+        when(locationService.getLocation("l2")).thenReturn(getLocation( "l2"));
+        when(dataFilterService.get(any(User.class), any(String.class))).thenReturn(new ArrayList<EntityBasisMap>());
+        when(userService.getUserByUsername(any(String.class))).thenReturn(user);
+
+        submissionFilter.doFilter(request, response, filterChain);
+
+        verify(locationService, times(2)).getLocation(any(String.class));
+        verify(dataFilterService).grantAccess(any(User.class), anyCollectionOf(OpenmrsObject.class));
+        verify(dataFilterService, never()).revokeAccess(any(User.class), anyCollectionOf(OpenmrsObject.class));
+    }
+
+    @Test
+    public void shouldGrantAndRevokeAccessToUser() throws IOException, ServletException {
+
+        HttpServletRequest request = buildMockHttpServletRequest("POST","user_x",new String[]{"l1","l2"});
+
+        MockHttpServletResponse response = buildMockHttpServletResponse();
+
+        User user = Mockito.mock(User.class);
+        when(locationService.getAllLocations()).thenReturn(getLocations(Arrays.asList("l1","l2","l3","l5","l7")));
+        when(locationService.getLocation("l1")).thenReturn(getLocation( "l1"));
+        when(locationService.getLocation("l2")).thenReturn(getLocation( "l2"));
+
+        when(userService.getUserByUsername(any(String.class))).thenReturn(user);
+        when(dataFilterService.get(any(User.class), any(String.class))).thenReturn(getEntityBasisMaps(Arrays.asList("1","3","4","6","7")));
+
+        Mockito.doNothing().when(filterChain).doFilter(request, response);
+
+        submissionFilter.doFilter(request, response, filterChain);
+
+        verify(dataFilterService).revokeAccess(any(User.class), (Collection<OpenmrsObject>) argThat(IsCollectionWithSize.hasSize(2)));
+        verify(dataFilterService).revokeAccess(any(User.class), (Collection<OpenmrsObject>) argThat(IsCollectionWithSize.hasSize(2)));
+    }
+
+    @Test
+    public void shouldNotGrandAccessIfUserUUIDIsNotValid() throws Exception {
+        HttpServletRequest request = buildMockHttpServletRequest("POST","",new String[]{"l1","l2"});
+
+        MockHttpServletResponse response = buildMockHttpServletResponse();
+        String invalid_uuid = "invalid-uuid";
+        response.addHeader("userUUID", invalid_uuid);
+
+        when(userService.getUserByUuid(invalid_uuid)).thenReturn(null);
+        submissionFilter.doFilter(request, response, filterChain);
+
+        verify(userService, never()).getUserByUsername(any(String.class));
+        verify(userService, times(1)).getUserByUuid(invalid_uuid);
+        verify(locationService, never()).getLocation(any(String.class));
+        verify(dataFilterService, never()).grantAccess(any(User.class), anyCollectionOf(OpenmrsObject.class));
+    }
+
+    @Test
+    public void shouldGrandAccessForUserByUUID() throws Exception {
+        HttpServletRequest request = buildMockHttpServletRequest("POST","",new String[]{"l1","l2"});
+
+        MockHttpServletResponse response = buildMockHttpServletResponse();
+        String uuid = "uuid";
+        response.addHeader("userUUID", uuid);
+
+        User user = new User();
+        when(locationService.getAllLocations()).thenReturn(getLocations(Arrays.asList("l1","l2","l3")));
+        when(locationService.getLocation("l1")).thenReturn(getLocation( "l1"));
+        when(locationService.getLocation("l2")).thenReturn(getLocation( "l2"));
+        when(dataFilterService.get(any(User.class), any(String.class))).thenReturn(new ArrayList<EntityBasisMap>());
+        when(userService.getUserByUuid(uuid)).thenReturn(user);
+
+        submissionFilter.doFilter(request, response, filterChain);
+
+        verify(userService,times(1)).getUserByUuid(uuid);
+        verify(locationService, times(2)).getLocation(any(String.class));
+        verify(dataFilterService).grantAccess(any(User.class), anyCollectionOf(OpenmrsObject.class));
+        verify(dataFilterService, never()).revokeAccess(any(User.class), anyCollectionOf(OpenmrsObject.class));
+    }
+
+    private HttpServletRequest buildMockHttpServletRequest(String method,String username,String[] locationStrings) {
+        HttpServletRequest request = new MockHttpServletRequest();
+        ((MockHttpServletRequest) request).setMethod(method);
+        ((MockHttpServletRequest) request).addParameter("locationStrings", locationStrings);
+        ((MockHttpServletRequest) request).addParameter("username", username);
+        return request;
+    }
+
+    private MockHttpServletResponse buildMockHttpServletResponse() {
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        response.setStatus(200);
+        return response;
+    }
+
+    private Collection<EntityBasisMap> getEntityBasisMaps(List<String> basisIdentifiers) {
+        List<EntityBasisMap> entityBasisMaps = new ArrayList<>();
+        basisIdentifiers.stream().forEach((basisIdentifier)->entityBasisMaps.add(getEntityBasisMap(basisIdentifier)));
+        return entityBasisMaps;
+    }
+
+    private EntityBasisMap getEntityBasisMap(String identifier) {
+        EntityBasisMap entityBasisMap = new EntityBasisMap();
+        entityBasisMap.setBasisIdentifier(identifier);
+        return entityBasisMap;
+    }
+
+    private List<Location> getLocations(List<String> locationNames) {
+        List<Location> allLocationsForLoggedInUser = new ArrayList<>();
+        locationNames.stream().forEach((locationName)->allLocationsForLoggedInUser.add(
+                getLocation(locationName)));
+        return allLocationsForLoggedInUser;
+    }
+
+    private Location getLocation(String locationName) {
+        Location location = new Location(Integer.parseInt(locationName.substring(1)));
+        location.setName(locationName);
+        return location;
+    }
+}


### PR DESCRIPTION
We would like to add implementation for datafilter UI. 

It would be an extension point implementation that would be plugged in legacy-ui userForm page.

Openmrs talk - https://talk.openmrs.org/t/add-extension-hook-in-add-edit-user-page-on-legacy-ui/26481
 
**PR for legacyUI** where extensionPoint is configured https://github.com/openmrs/openmrs-module-legacyui/pull/113

**Steps to test:**
1. Pick a reference application with legacyUI omod from ttps://github.com/openmrs/openmrs-module-legacyui/pull/112/files
2. Add the data filter omod built out of this branch
3. Navigate to the System Admin > Advanced Administration > Manage Users > Add User / Edit user

![image](https://user-images.githubusercontent.com/40290306/77535136-16971e00-6ec0-11ea-8890-03be1c3fa499.png)


