### PR TITLE
FILTER-5: Escaping location names in user management extension HTML.

### DIFF
--- a/omod/src/main/java/org/openmrs/module/datafilter/extension/html/Content.java
+++ b/omod/src/main/java/org/openmrs/module/datafilter/extension/html/Content.java
@@ -10,7 +10,7 @@
 
 package org.openmrs.module.datafilter.extension.html;
 
-import org.apache.commons.lang.StringEscapeUtils;
+import org.springframework.web.util.HtmlUtils;
 
 import java.util.List;
 
@@ -54,11 +54,11 @@ public class Content {
 			if (selectedLocations.contains(locationName)) {
 				checkedValue = CHECKED;
 			}
-			locationName = StringEscapeUtils.escapeHtml(locationName);
+			locationName = HtmlUtils.htmlEscape(locationName);
 			appendedContent += "<span class='listItem'>";
-			appendedContent += "<input type='checkbox' name='locationStrings' id=\"locationStrings." + locationName + "\""
-			        + " value=\"" + locationName + "\"" + checkedValue + ">";
-			appendedContent += "<label for=\"locationStrings." + locationName + "\">" + locationName + "</label>";
+			appendedContent += "<input type='checkbox' name='locationStrings' id='locationStrings." + locationName + "'"
+			        + " value='" + locationName + "'" + checkedValue + ">";
+			appendedContent += "<label for='locationStrings." + locationName + "'>" + locationName + "</label>";
 			appendedContent += "</span>";
 			return appendedContent;
 		});

--- a/omod/src/main/java/org/openmrs/module/datafilter/extension/html/Content.java
+++ b/omod/src/main/java/org/openmrs/module/datafilter/extension/html/Content.java
@@ -51,15 +51,14 @@ public class Content {
 	private String addHTMLForLocationNames() {
 		return locationNames.stream().reduce("", (appendedContent, locationName) -> {
 			String checkedValue = "";
-			String escapedLocationName = StringEscapeUtils.escapeHtml(locationName);
-			appendedContent += "<span class='listItem'>";
 			if (selectedLocations.contains(locationName)) {
 				checkedValue = CHECKED;
 			}
-			appendedContent += "<input type='checkbox' name='locationStrings' id=\"locationStrings." + escapedLocationName
-			        + "\"" + " value=\"" + escapedLocationName + "\"" + checkedValue + ">";
-			appendedContent += "<label for=\"locationStrings." + escapedLocationName + "\">" + escapedLocationName
-			        + "</label>";
+			locationName = StringEscapeUtils.escapeHtml(locationName);
+			appendedContent += "<span class='listItem'>";
+			appendedContent += "<input type='checkbox' name='locationStrings' id=\"locationStrings." + locationName + "\""
+			        + " value=\"" + locationName + "\"" + checkedValue + ">";
+			appendedContent += "<label for=\"locationStrings." + locationName + "\">" + locationName + "</label>";
 			appendedContent += "</span>";
 			return appendedContent;
 		});

--- a/omod/src/main/java/org/openmrs/module/datafilter/extension/html/Content.java
+++ b/omod/src/main/java/org/openmrs/module/datafilter/extension/html/Content.java
@@ -10,6 +10,8 @@
 
 package org.openmrs.module.datafilter.extension.html;
 
+import org.apache.commons.lang.StringEscapeUtils;
+
 import java.util.List;
 
 public class Content {
@@ -49,15 +51,18 @@ public class Content {
 	private String addHTMLForLocationNames() {
 		return locationNames.stream().reduce("", (appendedContent, locationName) -> {
 			String checkedValue = "";
+			String escapedLocationName = StringEscapeUtils.escapeHtml(locationName);
 			appendedContent += "<span class='listItem'>";
 			if (selectedLocations.contains(locationName)) {
 				checkedValue = CHECKED;
 			}
-			appendedContent += "<input type='checkbox' name='locationStrings' id='locationStrings." + locationName + "'"
-			        + " value='" + locationName + "'" + checkedValue + ">";
-			appendedContent += "<label for='locationStrings." + locationName + "'>" + locationName + "</label>";
+			appendedContent += "<input type='checkbox' name='locationStrings' id=\"locationStrings." + escapedLocationName
+			        + "\"" + " value=\"" + escapedLocationName + "\"" + checkedValue + ">";
+			appendedContent += "<label for=\"locationStrings." + escapedLocationName + "\">" + escapedLocationName
+			        + "</label>";
 			appendedContent += "</span>";
 			return appendedContent;
 		});
 	}
+	
 }

--- a/omod/src/test/java/org/openmrs/module/datafilter/extension/html/ContentTest.java
+++ b/omod/src/test/java/org/openmrs/module/datafilter/extension/html/ContentTest.java
@@ -26,12 +26,11 @@ public class ContentTest {
 		String expected = "<style>.listItemBoxCustom {width: 460px;padding: 2px;border: 1px solid lightgray;float: left;background-color: #EFEFEF;overflow-x: scroll;height: 200px;}</style>"
 		        + "<td valign='top'>Location</td>" + "<td valign='top'><div id='locationStrings' class='listItemBoxCustom'>"
 		        + "<span class='listItem'>"
-		        + "<input type='checkbox' name='locationStrings' id='locationStrings.L1' value='L1'><label for='locationStrings.L1'>L1</label>"
+		        + "<input type='checkbox' name='locationStrings' id=\"locationStrings.L1\" value=\"L1\"><label for=\"locationStrings.L1\">L1</label>"
 		        + "</span>" + "<span class='listItem'>"
-		        + "<input type='checkbox' name='locationStrings' id='locationStrings.L2' value='L2'><label for='locationStrings.L2'>L2</label>"
+		        + "<input type='checkbox' name='locationStrings' id=\"locationStrings.L2\" value=\"L2\"><label for=\"locationStrings.L2\">L2</label>"
 		        + "</span>" + "</div></td>";
 		assertEquals(expected, content.generate());
-		
 	}
 	
 	@Test
@@ -41,12 +40,25 @@ public class ContentTest {
 		String expected = "<style>.listItemBoxCustom {width: 460px;padding: 2px;border: 1px solid lightgray;float: left;background-color: #EFEFEF;overflow-x: scroll;height: 200px;}</style>"
 		        + "<td valign='top'>Location</td>" + "<td valign='top'><div id='locationStrings' class='listItemBoxCustom'>"
 		        + "<span class='listItem'>"
-		        + "<input type='checkbox' name='locationStrings' id='locationStrings.L1' value='L1'><label for='locationStrings.L1'>L1</label>"
+		        + "<input type='checkbox' name='locationStrings' id=\"locationStrings.L1\" value=\"L1\"><label for=\"locationStrings.L1\">L1</label>"
 		        + "</span>" + "<span class='listItem'>"
-		        + "<input type='checkbox' name='locationStrings' id='locationStrings.L2' value='L2' checked><label for='locationStrings.L2'>L2</label>"
+		        + "<input type='checkbox' name='locationStrings' id=\"locationStrings.L2\" value=\"L2\" checked><label for=\"locationStrings.L2\">L2</label>"
 		        + "</span>" + "</div></td>";
 		assertEquals(expected, content.generate());
+	}
+	
+	@Test
+	public void addLocationNameLineWithApostrophe() {
+		Content content = new Content(Arrays.asList("L'1", "L2"), new ArrayList<String>());
 		
+		String expected = "<style>.listItemBoxCustom {width: 460px;padding: 2px;border: 1px solid lightgray;float: left;background-color: #EFEFEF;overflow-x: scroll;height: 200px;}</style>"
+		        + "<td valign='top'>Location</td>" + "<td valign='top'><div id='locationStrings' class='listItemBoxCustom'>"
+		        + "<span class='listItem'>"
+		        + "<input type='checkbox' name='locationStrings' id=\"locationStrings.L'1\" value=\"L'1\"><label for=\"locationStrings.L'1\">L'1</label>"
+		        + "</span>" + "<span class='listItem'>"
+		        + "<input type='checkbox' name='locationStrings' id=\"locationStrings.L2\" value=\"L2\"><label for=\"locationStrings.L2\">L2</label>"
+		        + "</span>" + "</div></td>";
+		assertEquals(expected, content.generate());
 	}
 	
 	@Test

--- a/omod/src/test/java/org/openmrs/module/datafilter/extension/html/ContentTest.java
+++ b/omod/src/test/java/org/openmrs/module/datafilter/extension/html/ContentTest.java
@@ -21,12 +21,12 @@ public class ContentTest {
 	
 	@Test
 	public void addLocationNameLine() {
-		Content content = new Content(Arrays.asList("L1", "L2"), new ArrayList<String>());
+		Content content = new Content(Arrays.asList("L'1", "L2"), new ArrayList<String>());
 		
 		String expected = "<style>.listItemBoxCustom {width: 460px;padding: 2px;border: 1px solid lightgray;float: left;background-color: #EFEFEF;overflow-x: scroll;height: 200px;}</style>"
 		        + "<td valign='top'>Location</td>" + "<td valign='top'><div id='locationStrings' class='listItemBoxCustom'>"
 		        + "<span class='listItem'>"
-		        + "<input type='checkbox' name='locationStrings' id=\"locationStrings.L1\" value=\"L1\"><label for=\"locationStrings.L1\">L1</label>"
+		        + "<input type='checkbox' name='locationStrings' id=\"locationStrings.L'1\" value=\"L'1\"><label for=\"locationStrings.L'1\">L'1</label>"
 		        + "</span>" + "<span class='listItem'>"
 		        + "<input type='checkbox' name='locationStrings' id=\"locationStrings.L2\" value=\"L2\"><label for=\"locationStrings.L2\">L2</label>"
 		        + "</span>" + "</div></td>";
@@ -43,20 +43,6 @@ public class ContentTest {
 		        + "<input type='checkbox' name='locationStrings' id=\"locationStrings.L1\" value=\"L1\"><label for=\"locationStrings.L1\">L1</label>"
 		        + "</span>" + "<span class='listItem'>"
 		        + "<input type='checkbox' name='locationStrings' id=\"locationStrings.L2\" value=\"L2\" checked><label for=\"locationStrings.L2\">L2</label>"
-		        + "</span>" + "</div></td>";
-		assertEquals(expected, content.generate());
-	}
-	
-	@Test
-	public void addLocationNameLineWithApostrophe() {
-		Content content = new Content(Arrays.asList("L'1", "L2"), new ArrayList<String>());
-		
-		String expected = "<style>.listItemBoxCustom {width: 460px;padding: 2px;border: 1px solid lightgray;float: left;background-color: #EFEFEF;overflow-x: scroll;height: 200px;}</style>"
-		        + "<td valign='top'>Location</td>" + "<td valign='top'><div id='locationStrings' class='listItemBoxCustom'>"
-		        + "<span class='listItem'>"
-		        + "<input type='checkbox' name='locationStrings' id=\"locationStrings.L'1\" value=\"L'1\"><label for=\"locationStrings.L'1\">L'1</label>"
-		        + "</span>" + "<span class='listItem'>"
-		        + "<input type='checkbox' name='locationStrings' id=\"locationStrings.L2\" value=\"L2\"><label for=\"locationStrings.L2\">L2</label>"
 		        + "</span>" + "</div></td>";
 		assertEquals(expected, content.generate());
 	}

--- a/omod/src/test/java/org/openmrs/module/datafilter/extension/html/ContentTest.java
+++ b/omod/src/test/java/org/openmrs/module/datafilter/extension/html/ContentTest.java
@@ -26,9 +26,9 @@ public class ContentTest {
 		String expected = "<style>.listItemBoxCustom {width: 460px;padding: 2px;border: 1px solid lightgray;float: left;background-color: #EFEFEF;overflow-x: scroll;height: 200px;}</style>"
 		        + "<td valign='top'>Location</td>" + "<td valign='top'><div id='locationStrings' class='listItemBoxCustom'>"
 		        + "<span class='listItem'>"
-		        + "<input type='checkbox' name='locationStrings' id=\"locationStrings.L'1\" value=\"L'1\"><label for=\"locationStrings.L'1\">L'1</label>"
+		        + "<input type='checkbox' name='locationStrings' id='locationStrings.L&#39;1' value='L&#39;1'><label for='locationStrings.L&#39;1'>L&#39;1</label>"
 		        + "</span>" + "<span class='listItem'>"
-		        + "<input type='checkbox' name='locationStrings' id=\"locationStrings.L2\" value=\"L2\"><label for=\"locationStrings.L2\">L2</label>"
+		        + "<input type='checkbox' name='locationStrings' id='locationStrings.L2' value='L2'><label for='locationStrings.L2'>L2</label>"
 		        + "</span>" + "</div></td>";
 		assertEquals(expected, content.generate());
 	}
@@ -40,9 +40,9 @@ public class ContentTest {
 		String expected = "<style>.listItemBoxCustom {width: 460px;padding: 2px;border: 1px solid lightgray;float: left;background-color: #EFEFEF;overflow-x: scroll;height: 200px;}</style>"
 		        + "<td valign='top'>Location</td>" + "<td valign='top'><div id='locationStrings' class='listItemBoxCustom'>"
 		        + "<span class='listItem'>"
-		        + "<input type='checkbox' name='locationStrings' id=\"locationStrings.L1\" value=\"L1\"><label for=\"locationStrings.L1\">L1</label>"
+		        + "<input type='checkbox' name='locationStrings' id='locationStrings.L1' value='L1'><label for='locationStrings.L1'>L1</label>"
 		        + "</span>" + "<span class='listItem'>"
-		        + "<input type='checkbox' name='locationStrings' id=\"locationStrings.L2\" value=\"L2\" checked><label for=\"locationStrings.L2\">L2</label>"
+		        + "<input type='checkbox' name='locationStrings' id='locationStrings.L2' value='L2' checked><label for='locationStrings.L2'>L2</label>"
 		        + "</span>" + "</div></td>";
 		assertEquals(expected, content.generate());
 	}

--- a/omod/src/test/java/org/openmrs/module/datafilter/extension/html/LocationExtTest.java
+++ b/omod/src/test/java/org/openmrs/module/datafilter/extension/html/LocationExtTest.java
@@ -63,10 +63,8 @@ public class LocationExtTest {
 	public void shouldGenerateContentWithNoSelectedLocationsWhenUserHasNoLocationsMapped() {
 		locationExt.setParameterMap(new HashMap<String, String>());
 		String content = locationExt.getOverrideContent("");
-		assertTrue(
-		    content.contains("<input type='checkbox' name='locationStrings' id=\"locationStrings.l1\" value=\"l1\">"));
-		assertTrue(
-		    content.contains("<input type='checkbox' name='locationStrings' id=\"locationStrings.l2\" value=\"l2\">"));
+		assertTrue(content.contains("<input type='checkbox' name='locationStrings' id='locationStrings.l1' value='l1'>"));
+		assertTrue(content.contains("<input type='checkbox' name='locationStrings' id='locationStrings.l2' value='l2'>"));
 	}
 	
 	@Test
@@ -86,10 +84,9 @@ public class LocationExtTest {
 		
 		String content = locationExt.getOverrideContent("");
 		
+		assertTrue(content.contains("<input type='checkbox' name='locationStrings' id='locationStrings.l1' value='l1'>"));
 		assertTrue(
-		    content.contains("<input type='checkbox' name='locationStrings' id=\"locationStrings.l1\" value=\"l1\">"));
-		assertTrue(content
-		        .contains("<input type='checkbox' name='locationStrings' id=\"locationStrings.l2\" value=\"l2\" checked>"));
+		    content.contains("<input type='checkbox' name='locationStrings' id='locationStrings.l2' value='l2' checked>"));
 		;
 	}
 	

--- a/omod/src/test/java/org/openmrs/module/datafilter/extension/html/LocationExtTest.java
+++ b/omod/src/test/java/org/openmrs/module/datafilter/extension/html/LocationExtTest.java
@@ -63,8 +63,10 @@ public class LocationExtTest {
 	public void shouldGenerateContentWithNoSelectedLocationsWhenUserHasNoLocationsMapped() {
 		locationExt.setParameterMap(new HashMap<String, String>());
 		String content = locationExt.getOverrideContent("");
-		assertTrue(content.contains("<input type='checkbox' name='locationStrings' id='locationStrings.l1' value='l1'>"));
-		assertTrue(content.contains("<input type='checkbox' name='locationStrings' id='locationStrings.l2' value='l2'>"));
+		assertTrue(
+		    content.contains("<input type='checkbox' name='locationStrings' id=\"locationStrings.l1\" value=\"l1\">"));
+		assertTrue(
+		    content.contains("<input type='checkbox' name='locationStrings' id=\"locationStrings.l2\" value=\"l2\">"));
 	}
 	
 	@Test
@@ -84,9 +86,10 @@ public class LocationExtTest {
 		
 		String content = locationExt.getOverrideContent("");
 		
-		assertTrue(content.contains("<input type='checkbox' name='locationStrings' id='locationStrings.l1' value='l1'>"));
 		assertTrue(
-		    content.contains("<input type='checkbox' name='locationStrings' id='locationStrings.l2' value='l2' checked>"));
+		    content.contains("<input type='checkbox' name='locationStrings' id=\"locationStrings.l1\" value=\"l1\">"));
+		assertTrue(content
+		        .contains("<input type='checkbox' name='locationStrings' id=\"locationStrings.l2\" value=\"l2\" checked>"));
 		;
 	}
 	


### PR DESCRIPTION
## Issue I worked on
<!--- This project only accepts pull requests related to open issues -->
<!--- Want a new feature or change? Discuss it in an issue first -->
<!--- Found a bug? Point us to the issue/or create one so we can reproduce it -->
<!--- Just add the issue number at the end: -->
see https://issues.openmrs.org/browse/FILTER-5