### PR TITLE
FILTER-8: Added support for the removal of all user's locations.

### DIFF
--- a/omod/src/main/java/org/openmrs/module/datafilter/extension/html/Content.java
+++ b/omod/src/main/java/org/openmrs/module/datafilter/extension/html/Content.java
@@ -35,7 +35,7 @@ public class Content {
 	public Content(List<String> locationNames, List<String> selectedLocations) {
 		this.locationNames = locationNames;
 		this.selectedLocations = selectedLocations;
-		this.styles = "<style>.listItemBoxCustom {width: 460px;" + "padding: 2px;" + "border: 1px solid lightgray;"
+		this.styles = "<style>.listItemBoxCustom {width: 440px;" + "padding: 2px;" + "border: 1px solid lightgray;"
 		        + "float: left;" + "background-color: #EFEFEF;" + "overflow-x: scroll;" + "height: 200px;}" + "</style>";
 		this.scripts = "";
 		this.title = "Location";

--- a/omod/src/main/java/org/openmrs/module/datafilter/web/UserFormSubmissionHandler.java
+++ b/omod/src/main/java/org/openmrs/module/datafilter/web/UserFormSubmissionHandler.java
@@ -74,21 +74,19 @@ public class UserFormSubmissionHandler {
 				log.info("User details missing or Invalid user details");
 				return;
 			}
-			String[] locationStrings = request.getParameterValues("locationStrings");
-			if (locationStrings == null) {
+
+			String[] locationStrings = request.getParameterValues("locationStrings") != null ? request.getParameterValues("locationStrings") : new String[0];
+			Collection<EntityBasisMap> mappedLocationsMap = dataFilterService.getEntityBasisMaps(user, Location.class.getName());
+			List<OpenmrsObject> locationsToBeRevoked = getLocationsToBeRevoked(locationService.getAllLocations(), mappedLocationsMap, locationStrings);
+			if (!locationsToBeRevoked.isEmpty()) {
+				dataFilterService.revokeAccess(user, locationsToBeRevoked);
+			}
+			if (locationStrings.length < 1) {
 				log.info("No locations selected");
 				return;
 			}
 			Set<OpenmrsObject> allSelectedLocations = Arrays.stream(locationStrings).map(l -> locationService.getLocation(l))
-			        .filter(Objects::nonNull).collect(Collectors.toSet());
-			
-			Collection<EntityBasisMap> mappedLocationsMap = dataFilterService.getEntityBasisMaps(user,
-			    Location.class.getName());
-			List<OpenmrsObject> locationsToBeRevoked = getLocationsToBeRevoked(locationService.getAllLocations(),
-			    mappedLocationsMap, locationStrings);
-			if (!locationsToBeRevoked.isEmpty()) {
-				dataFilterService.revokeAccess(user, locationsToBeRevoked);
-			}
+					.filter(Objects::nonNull).collect(Collectors.toSet());
 			if (!allSelectedLocations.isEmpty()) {
 				dataFilterService.grantAccess(user, allSelectedLocations);
 			}

--- a/omod/src/main/java/org/openmrs/module/datafilter/web/UserFormSubmissionHandler.java
+++ b/omod/src/main/java/org/openmrs/module/datafilter/web/UserFormSubmissionHandler.java
@@ -74,10 +74,14 @@ public class UserFormSubmissionHandler {
 				log.info("User details missing or Invalid user details");
 				return;
 			}
-
-			String[] locationStrings = request.getParameterValues("locationStrings") != null ? request.getParameterValues("locationStrings") : new String[0];
-			Collection<EntityBasisMap> mappedLocationsMap = dataFilterService.getEntityBasisMaps(user, Location.class.getName());
-			List<OpenmrsObject> locationsToBeRevoked = getLocationsToBeRevoked(locationService.getAllLocations(), mappedLocationsMap, locationStrings);
+			
+			String[] locationStrings = request.getParameterValues("locationStrings") != null
+			        ? request.getParameterValues("locationStrings")
+			        : new String[0];
+			Collection<EntityBasisMap> mappedLocationsMap = dataFilterService.getEntityBasisMaps(user,
+			    Location.class.getName());
+			List<OpenmrsObject> locationsToBeRevoked = getLocationsToBeRevoked(locationService.getAllLocations(),
+			    mappedLocationsMap, locationStrings);
 			if (!locationsToBeRevoked.isEmpty()) {
 				dataFilterService.revokeAccess(user, locationsToBeRevoked);
 			}
@@ -86,7 +90,7 @@ public class UserFormSubmissionHandler {
 				return;
 			}
 			Set<OpenmrsObject> allSelectedLocations = Arrays.stream(locationStrings).map(l -> locationService.getLocation(l))
-					.filter(Objects::nonNull).collect(Collectors.toSet());
+			        .filter(Objects::nonNull).collect(Collectors.toSet());
 			if (!allSelectedLocations.isEmpty()) {
 				dataFilterService.grantAccess(user, allSelectedLocations);
 			}

--- a/omod/src/test/java/org/openmrs/module/datafilter/extension/html/ContentTest.java
+++ b/omod/src/test/java/org/openmrs/module/datafilter/extension/html/ContentTest.java
@@ -23,7 +23,7 @@ public class ContentTest {
 	public void addLocationNameLine() {
 		Content content = new Content(Arrays.asList("L'1", "L2"), new ArrayList<String>());
 		
-		String expected = "<style>.listItemBoxCustom {width: 460px;padding: 2px;border: 1px solid lightgray;float: left;background-color: #EFEFEF;overflow-x: scroll;height: 200px;}</style>"
+		String expected = "<style>.listItemBoxCustom {width: 440px;padding: 2px;border: 1px solid lightgray;float: left;background-color: #EFEFEF;overflow-x: scroll;height: 200px;}</style>"
 		        + "<td valign='top'>Location</td>" + "<td valign='top'><div id='locationStrings' class='listItemBoxCustom'>"
 		        + "<span class='listItem'>"
 		        + "<input type='checkbox' name='locationStrings' id='locationStrings.L&#39;1' value='L&#39;1'><label for='locationStrings.L&#39;1'>L&#39;1</label>"
@@ -37,7 +37,7 @@ public class ContentTest {
 	public void addLocationNameLineWithMappedLocationsChecked() {
 		Content content = new Content(Arrays.asList("L1", "L2"), Arrays.asList("L2"));
 		
-		String expected = "<style>.listItemBoxCustom {width: 460px;padding: 2px;border: 1px solid lightgray;float: left;background-color: #EFEFEF;overflow-x: scroll;height: 200px;}</style>"
+		String expected = "<style>.listItemBoxCustom {width: 440px;padding: 2px;border: 1px solid lightgray;float: left;background-color: #EFEFEF;overflow-x: scroll;height: 200px;}</style>"
 		        + "<td valign='top'>Location</td>" + "<td valign='top'><div id='locationStrings' class='listItemBoxCustom'>"
 		        + "<span class='listItem'>"
 		        + "<input type='checkbox' name='locationStrings' id='locationStrings.L1' value='L1'><label for='locationStrings.L1'>L1</label>"
@@ -49,7 +49,7 @@ public class ContentTest {
 	
 	@Test
 	public void getFullContent() {
-		String expected = "<style>.listItemBoxCustom {width: 460px;padding: 2px;border: 1px solid lightgray;float: left;background-color: #EFEFEF;overflow-x: scroll;height: 200px;}</style>"
+		String expected = "<style>.listItemBoxCustom {width: 440px;padding: 2px;border: 1px solid lightgray;float: left;background-color: #EFEFEF;overflow-x: scroll;height: 200px;}</style>"
 		        + "<td valign='top'>Location</td>"
 		        + "<td valign='top'><div id='locationStrings' class='listItemBoxCustom'></div></td>";
 		assertEquals(expected, new Content(new ArrayList<>(), new ArrayList<>()).generate());


### PR DESCRIPTION
Issue: https://issues.openmrs.org/browse/RA-1886

When editing a user, its not possible to remove all locations:

How to reproduce:
Step 1) Edit a user that has locations assigned
Step 2) Remove all the locations at the same time
Step 3) Save the changes
Step 4) Unfortunately, the user will keep all the locations

Solution:
If the list of locations ("locationStrings") is null,
Now, we create a empty String array
This way the function "getLocationsToBeRevoked" will work as expected and remove all locations
(This happens because getLocationsToBeRevoked will compare existing locations with the "locationStrings" )