### PR TITLE
FILTER-9: Add encounter type filter for 1.x

### DIFF
--- a/api/src/main/java/org/openmrs/module/datafilter/impl/ImplConstants.java
+++ b/api/src/main/java/org/openmrs/module/datafilter/impl/ImplConstants.java
@@ -64,7 +64,10 @@ public final class ImplConstants {
 	
 	public static final String ENC_TYPE_PRIV_BASED_FILTER_NAME_ENCOUNTER = ENC_TYPE_PRIV_BASED_FILTER_NAME_PREFIX
 	        + "EncounterFilter";
-	
+
+	public static final String ENC_TYPE_PRIV_BASED_FILTER_NAME_ENCOUNTER_TYPE = ENC_TYPE_PRIV_BASED_FILTER_NAME_PREFIX
+			+ "EncounterTypeFilter";
+
 	public static final String ENC_TYPE_PRIV_BASED_FILTER_NAME_OBS = ENC_TYPE_PRIV_BASED_FILTER_NAME_PREFIX + "ObsFilter";
 	
 	public static final String ENC_TYPE_PRIV_BASED_FILTER_NAME_DIAGNOSIS = ENC_TYPE_PRIV_BASED_FILTER_NAME_PREFIX
@@ -84,7 +87,8 @@ public final class ImplConstants {
 	
 	public static final Set<String> ENC_TYPE_VIEW_PRIV_FILTER_NAMES = Stream
 	        .of(ENC_TYPE_PRIV_BASED_FILTER_NAME_ENCOUNTER, ENC_TYPE_PRIV_BASED_FILTER_NAME_OBS,
-	            ENC_TYPE_PRIV_BASED_FILTER_NAME_DIAGNOSIS, ENC_TYPE_PRIV_BASED_FILTER_NAME_CONDITION)
+	            ENC_TYPE_PRIV_BASED_FILTER_NAME_DIAGNOSIS, ENC_TYPE_PRIV_BASED_FILTER_NAME_CONDITION,
+					ENC_TYPE_PRIV_BASED_FILTER_NAME_ENCOUNTER_TYPE)
 	        .collect(Collectors.toSet());
 	
 	public static final Set<String> FILTER_NAMES;
@@ -140,7 +144,10 @@ public final class ImplConstants {
 	
 	public static final String GP_ENC_TYPE_PRIV_BASED_FILTER_NAME_CONDITION = ENC_TYPE_PRIV_BASED_FILTER_NAME_CONDITION
 	        + DISABLED;
-	
+
+	public static final String GP_ENC_TYPE_PRIV_BASED_FILTER_NAME_ENCOUNTER_TYPE = ENC_TYPE_PRIV_BASED_FILTER_NAME_ENCOUNTER_TYPE
+			+ DISABLED;
+
 	public static final String GP_RUN_IN_STRICT_MODE = MODULE_ID + ".runInStrictMode";
 	
 	public static final String GP_PAT_LOC_INTERCEPTOR_ENABLED = MODULE_ID + ".patientLocationLinkingInterceptor" + ENABLED;

--- a/api/src/main/java/org/openmrs/module/datafilter/impl/api/db/hibernate/AccessInterceptor.java
+++ b/api/src/main/java/org/openmrs/module/datafilter/impl/api/db/hibernate/AccessInterceptor.java
@@ -59,7 +59,8 @@ public class AccessInterceptor extends EmptyInterceptor {
 		encTypeBasedClassAndFiltersMap = new HashMap();
 		encTypeBasedClassAndFiltersMap.put(Encounter.class, ImplConstants.ENC_TYPE_PRIV_BASED_FILTER_NAME_ENCOUNTER);
 		encTypeBasedClassAndFiltersMap.put(Obs.class, ImplConstants.ENC_TYPE_PRIV_BASED_FILTER_NAME_OBS);
-		encTypeBasedClassAndFiltersMap.put(EncounterType.class, ImplConstants.ENC_TYPE_PRIV_BASED_FILTER_NAME_ENCOUNTER_TYPE);
+		encTypeBasedClassAndFiltersMap.put(EncounterType.class,
+		    ImplConstants.ENC_TYPE_PRIV_BASED_FILTER_NAME_ENCOUNTER_TYPE);
 	}
 	
 	/**

--- a/api/src/main/java/org/openmrs/module/datafilter/impl/api/db/hibernate/AccessInterceptor.java
+++ b/api/src/main/java/org/openmrs/module/datafilter/impl/api/db/hibernate/AccessInterceptor.java
@@ -59,6 +59,7 @@ public class AccessInterceptor extends EmptyInterceptor {
 		encTypeBasedClassAndFiltersMap = new HashMap();
 		encTypeBasedClassAndFiltersMap.put(Encounter.class, ImplConstants.ENC_TYPE_PRIV_BASED_FILTER_NAME_ENCOUNTER);
 		encTypeBasedClassAndFiltersMap.put(Obs.class, ImplConstants.ENC_TYPE_PRIV_BASED_FILTER_NAME_OBS);
+		encTypeBasedClassAndFiltersMap.put(EncounterType.class, ImplConstants.ENC_TYPE_PRIV_BASED_FILTER_NAME_ENCOUNTER_TYPE);
 	}
 	
 	/**
@@ -140,6 +141,8 @@ public class AccessInterceptor extends EmptyInterceptor {
 			if (entity instanceof Encounter) {
 				int encounterTypeIndex = ArrayUtils.indexOf(propertyNames, "encounterType");
 				encounterTypeId = ((EncounterType) state[encounterTypeIndex]).getEncounterTypeId();
+			} else if (entity instanceof EncounterType) {
+				encounterTypeId = ((EncounterType) entity).getEncounterTypeId();
 			} else {
 				//This is an Obs
 				int encounterIndex = ArrayUtils.indexOf(propertyNames, "encounter");

--- a/api/src/main/resources/filters/hibernate/enc_type_privilege.json
+++ b/api/src/main/resources/filters/hibernate/enc_type_privilege.json
@@ -58,5 +58,18 @@
         ],
         "property" : "encounters",
         "condition" : "encounter_id IN (SELECT DISTINCT e.encounter_id FROM encounter e INNER JOIN encounter_type et ON e.encounter_type = et.encounter_type_id WHERE et.view_privilege IS NULL OR et.view_privilege IN (SELECT DISTINCT rp.privilege FROM role_privilege rp WHERE rp.role IN (:roles)))"
+    },
+    {
+        "name" : "datafilter_encTypePrivBasedEncounterTypeFilter",
+        "targetClasses" : [
+            "org.openmrs.EncounterType"
+        ],
+        "condition" : "encounter_type_id in (SELECT DISTINCT et.encounter_type_id FROM encounter_type et WHERE et.view_privilege IS NULL OR et.view_privilege IN (SELECT DISTINCT rp.privilege FROM role_privilege rp WHERE rp.role IN (:roles)))",
+        "parameters" : [
+            {
+                "name" : "roles",
+                "type" : "string"
+            }
+        ]
     }
 ]

--- a/api/src/test/java/org/openmrs/module/datafilter/DataFilterBeanFactoryPostProcessorIntegrationTest.java
+++ b/api/src/test/java/org/openmrs/module/datafilter/DataFilterBeanFactoryPostProcessorIntegrationTest.java
@@ -28,9 +28,9 @@ public class DataFilterBeanFactoryPostProcessorIntegrationTest extends BaseFilte
 	
 	@Test
 	public void postProcessBeanFactory_shouldRegisterFiltersToHbmFiles() {
-		assertEquals(19, Util.getHibernateFilterRegistrations().size());
+		assertEquals(20, Util.getHibernateFilterRegistrations().size());
 		Set<String> registeredFilters = sessionFactory.getDefinedFilterNames();
-		assertEquals(18, registeredFilters.size());
+		assertEquals(19, registeredFilters.size());
 		for (String filterName : testXMlFilters) {
 			registeredFilters.contains(filterName);
 		}

--- a/api/src/test/java/org/openmrs/module/datafilter/UtilTest.java
+++ b/api/src/test/java/org/openmrs/module/datafilter/UtilTest.java
@@ -115,7 +115,7 @@ public class UtilTest {
 	
 	@Test
 	public void loadHibernateFilterRegistrations_shouldLoadAllHibernateFilterRegistrations() {
-		assertEquals(19, Util.getHibernateFilterRegistrations().size());
+		assertEquals(20, Util.getHibernateFilterRegistrations().size());
 	}
 	
 	@Test

--- a/api/src/test/java/org/openmrs/module/datafilter/impl/DataFilterTestUtils.java
+++ b/api/src/test/java/org/openmrs/module/datafilter/impl/DataFilterTestUtils.java
@@ -9,6 +9,7 @@
  */
 package org.openmrs.module.datafilter.impl;
 
+import static org.openmrs.module.datafilter.impl.ImplConstants.GP_ENC_TYPE_PRIV_BASED_FILTER_NAME_ENCOUNTER_TYPE;
 import static org.openmrs.module.datafilter.impl.ImplConstants.GP_ENC_TYPE_PRIV_BASED_FILTER_NAME_CONDITION;
 import static org.openmrs.module.datafilter.impl.ImplConstants.GP_ENC_TYPE_PRIV_BASED_FILTER_NAME_DIAGNOSIS;
 import static org.openmrs.module.datafilter.impl.ImplConstants.GP_ENC_TYPE_PRIV_BASED_FILTER_NAME_ENCOUNTER;
@@ -62,6 +63,7 @@ public class DataFilterTestUtils {
 		as.setGlobalProperty(GP_ENC_TYPE_PRIV_BASED_FILTER_NAME_ENCOUNTER, "true");
 		as.setGlobalProperty(GP_ENC_TYPE_PRIV_BASED_FILTER_NAME_DIAGNOSIS, "true");
 		as.setGlobalProperty(GP_ENC_TYPE_PRIV_BASED_FILTER_NAME_CONDITION, "true");
+		as.setGlobalProperty(GP_ENC_TYPE_PRIV_BASED_FILTER_NAME_ENCOUNTER_TYPE, "true");
 		Context.flushSession();
 	}
 	

--- a/api/src/test/java/org/openmrs/module/datafilter/impl/EncTypePrivilegeBasedFilterTest.java
+++ b/api/src/test/java/org/openmrs/module/datafilter/impl/EncTypePrivilegeBasedFilterTest.java
@@ -56,7 +56,6 @@ public class EncTypePrivilegeBasedFilterTest extends BaseEncTypeViewPrivilegeBas
 	
 	@Test
 	public void getCondition_shouldReturnAllEncounterTypesIfTheAuthenticatedUserIsASuperUser() {
-		reloginAs("dyorke", "test");
 		assertTrue(Context.getAuthenticatedUser().isSuperUser());
 		List encounterTypes = sessionFactory.getCurrentSession().createCriteria(EncounterType.class).list();
 		assertEquals(4, encounterTypes.size());
@@ -64,7 +63,6 @@ public class EncTypePrivilegeBasedFilterTest extends BaseEncTypeViewPrivilegeBas
 	
 	@Test
 	public void getCondition_shouldReturnAllEncounterTypesIfEncTypeViewPrivFilteringIsDisabled() {
-		reloginAs("dyorke", "test");
 		DataFilterTestUtils.disableEncTypeViewPrivilegeFiltering();
 		List encounterTypes = sessionFactory.getCurrentSession().createCriteria(EncounterType.class).list();
 		assertEquals(4, encounterTypes.size());

--- a/api/src/test/java/org/openmrs/module/datafilter/impl/EncTypePrivilegeBasedFilterTest.java
+++ b/api/src/test/java/org/openmrs/module/datafilter/impl/EncTypePrivilegeBasedFilterTest.java
@@ -16,9 +16,7 @@ import org.openmrs.EncounterType;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.datafilter.TestConstants;
 import org.springframework.beans.factory.annotation.Autowired;
-
 import java.util.List;
-
 import static org.junit.Assert.*;
 
 public class EncTypePrivilegeBasedFilterTest extends BaseEncTypeViewPrivilegeBasedFilterTest {
@@ -44,7 +42,6 @@ public class EncTypePrivilegeBasedFilterTest extends BaseEncTypeViewPrivilegeBas
 		expCount = 4;
 		ecounterTypelist = sessionFactory.getCurrentSession().createCriteria(EncounterType.class).list();
 		assertEquals(expCount, ecounterTypelist.size());
-		
 	}
 	
 	@Test

--- a/api/src/test/java/org/openmrs/module/datafilter/impl/EncTypePrivilegeBasedFilterTest.java
+++ b/api/src/test/java/org/openmrs/module/datafilter/impl/EncTypePrivilegeBasedFilterTest.java
@@ -47,22 +47,22 @@ public class EncTypePrivilegeBasedFilterTest extends BaseEncTypeViewPrivilegeBas
 	}
 
 	@Test
-	public void getCondition_shouldNotReturnEncounterTypesThatRequireAPrivilege() {
+	public void getEncounterType_shouldNotReturnEncounterTypesThatRequireAPrivilege() {
 		reloginAs("dyorke", "test");
 		assertFalse(Context.getAuthenticatedUser().hasPrivilege(PRIV_MANAGE_CHEMO_PATIENTS));
 		List encounterTypes = sessionFactory.getCurrentSession().createCriteria(EncounterType.class).list();
 		assertEquals(3, encounterTypes.size());
 	}
-	
+
 	@Test
-	public void getCondition_shouldReturnAllEncounterTypesIfTheAuthenticatedUserIsASuperUser() {
+	public void getEncounterType_shouldReturnAllEncounterTypesIfTheAuthenticatedUserIsASuperUser() {
 		assertTrue(Context.getAuthenticatedUser().isSuperUser());
 		List encounterTypes = sessionFactory.getCurrentSession().createCriteria(EncounterType.class).list();
 		assertEquals(4, encounterTypes.size());
 	}
 	
 	@Test
-	public void getCondition_shouldReturnAllEncounterTypesIfEncTypeViewPrivFilteringIsDisabled() {
+	public void getEncounterType_shouldReturnAllEncounterTypesIfEncTypeViewPrivFilteringIsDisabled() {
 		DataFilterTestUtils.disableEncTypeViewPrivilegeFiltering();
 		List encounterTypes = sessionFactory.getCurrentSession().createCriteria(EncounterType.class).list();
 		assertEquals(4, encounterTypes.size());

--- a/api/src/test/java/org/openmrs/module/datafilter/impl/EncTypePrivilegeBasedFilterTest.java
+++ b/api/src/test/java/org/openmrs/module/datafilter/impl/EncTypePrivilegeBasedFilterTest.java
@@ -1,0 +1,65 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.datafilter.impl;
+
+import org.hibernate.SessionFactory;
+import org.junit.Before;
+import org.junit.Test;
+import org.openmrs.EncounterType;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.datafilter.TestConstants;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+public class EncTypePrivilegeBasedFilterTest extends BaseEncTypeViewPrivilegeBasedFilterTest {
+	
+	@Autowired
+	private SessionFactory sessionFactory;
+	
+	@Before
+	public void before() {
+		executeDataSet(TestConstants.ROOT_PACKAGE_DIR + "privilegedEncounters.xml");
+	}
+	
+	@Test
+	public void getEncounterType_shouldIncludeEncountersThatRequireAPrivilegeAndTheUserHasIt() {
+		reloginAs("dyorke", "test");
+		assertFalse(Context.getAuthenticatedUser().hasPrivilege(PRIV_MANAGE_CHEMO_PATIENTS));
+		
+		int expCount = 3;
+		List ecounterTypelist = sessionFactory.getCurrentSession().createCriteria(EncounterType.class).list();
+		assertEquals(expCount, ecounterTypelist.size());
+		
+		DataFilterTestUtils.addPrivilege(PRIV_MANAGE_CHEMO_PATIENTS);
+		expCount = 4;
+		ecounterTypelist = sessionFactory.getCurrentSession().createCriteria(EncounterType.class).list();
+		assertEquals(expCount, ecounterTypelist.size());
+		
+	}
+	
+	@Test
+	public void getCondition_shouldReturnAllEncounterTypesIfTheAuthenticatedUserIsASuperUser() {
+		assertTrue(Context.getAuthenticatedUser().isSuperUser());
+		List encounterTypes = sessionFactory.getCurrentSession().createCriteria(EncounterType.class).list();
+		System.out.println(encounterTypes);
+		assertEquals(4, encounterTypes.size());
+	}
+	
+	@Test
+	public void getCondition_shouldReturnAllEncounterTypesIfEncTypeViewPrivFilteringIsDisabled() {
+		DataFilterTestUtils.disableEncTypeViewPrivilegeFiltering();
+		List encounterTypes = sessionFactory.getCurrentSession().createCriteria(EncounterType.class).list();
+		assertEquals(4, encounterTypes.size());
+	}
+	
+}

--- a/api/src/test/java/org/openmrs/module/datafilter/impl/EncTypePrivilegeBasedFilterTest.java
+++ b/api/src/test/java/org/openmrs/module/datafilter/impl/EncTypePrivilegeBasedFilterTest.java
@@ -17,7 +17,9 @@ import org.openmrs.api.context.Context;
 import org.openmrs.module.datafilter.TestConstants;
 import org.springframework.beans.factory.annotation.Autowired;
 import java.util.List;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class EncTypePrivilegeBasedFilterTest extends BaseEncTypeViewPrivilegeBasedFilterTest {
 	
@@ -43,20 +45,28 @@ public class EncTypePrivilegeBasedFilterTest extends BaseEncTypeViewPrivilegeBas
 		ecounterTypelist = sessionFactory.getCurrentSession().createCriteria(EncounterType.class).list();
 		assertEquals(expCount, ecounterTypelist.size());
 	}
+
+	@Test
+	public void getCondition_shouldNotReturnEncounterTypesThatRequireAPrivilege() {
+		reloginAs("dyorke", "test");
+		assertFalse(Context.getAuthenticatedUser().hasPrivilege(PRIV_MANAGE_CHEMO_PATIENTS));
+		List encounterTypes = sessionFactory.getCurrentSession().createCriteria(EncounterType.class).list();
+		assertEquals(3, encounterTypes.size());
+	}
 	
 	@Test
 	public void getCondition_shouldReturnAllEncounterTypesIfTheAuthenticatedUserIsASuperUser() {
+		reloginAs("dyorke", "test");
 		assertTrue(Context.getAuthenticatedUser().isSuperUser());
 		List encounterTypes = sessionFactory.getCurrentSession().createCriteria(EncounterType.class).list();
-		System.out.println(encounterTypes);
 		assertEquals(4, encounterTypes.size());
 	}
 	
 	@Test
 	public void getCondition_shouldReturnAllEncounterTypesIfEncTypeViewPrivFilteringIsDisabled() {
+		reloginAs("dyorke", "test");
 		DataFilterTestUtils.disableEncTypeViewPrivilegeFiltering();
 		List encounterTypes = sessionFactory.getCurrentSession().createCriteria(EncounterType.class).list();
 		assertEquals(4, encounterTypes.size());
 	}
-	
 }

--- a/api/src/test/resources/org/openmrs/module/datafilter/moduleTestData.xml
+++ b/api/src/test/resources/org/openmrs/module/datafilter/moduleTestData.xml
@@ -51,6 +51,7 @@
     <privilege privilege="Get Users" description="Can View Users" uuid="ee80cb6d-c291-46c8-8d3a-96dc33d188fc" />
     <privilege privilege="Get Providers" description="Can View Users" uuid="fe80cb6d-c291-46c8-8d3a-96dc33d188fc" />
     <privilege privilege="Get Locations" description="Can View Locations" uuid="ge80cb6d-c291-46c8-8d3a-96dc33d188fc" />
+    <privilege privilege="Get Encounter Types" description="Can View Encounter Types" uuid="2327400d-4ff4-4663-a177-28ffe9d5f780" />
 
     <role role="Physician" description="Physician" uuid="1280cb6d-c291-46c8-8d3a-96dc33d199fc" />
 
@@ -61,6 +62,7 @@
     <role_privilege role="Physician" privilege="Get Users" />
     <role_privilege role="Physician" privilege="Get Providers" />
     <role_privilege role="Physician" privilege="Get Locations" />
+    <role_privilege role="Physician" privilege="Get Encounter Types" />
 
     <user_role user_id="3000" role="Physician" />
     <user_role user_id="3001" role="Physician" />


### PR DESCRIPTION
Issue: https://issues.openmrs.org/browse/FILTER-9

Objective:
It should be possible to filter encounter types according with user permissions.

This is the same change found on https://github.com/openmrs/openmrs-module-datafilter/pull/14 but for version 1.x