### PR TITLE
INFRA-378: Added support for OCD3 builds.

### DIFF
--- a/.ocd3.yml
+++ b/.ocd3.yml
@@ -1,0 +1,6 @@
+version: 1
+build:
+  bash_commands: "mvn clean install"
+deploy:
+  # Do not deploy via OCD3. Publishing is done via Bamboo.
+  bash_commands: "exit 0"


### PR DESCRIPTION
Allow Mekom's CI/CD to build the artifact.
Skip any publishing step though as this is done via Bamboo already.