### PR TITLE
FILTER-16: Fix silent failure in integration test asserts

### DIFF
--- a/api/src/test/java/org/openmrs/module/datafilter/DataFilterBeanFactoryPostProcessorIntegrationTest.java
+++ b/api/src/test/java/org/openmrs/module/datafilter/DataFilterBeanFactoryPostProcessorIntegrationTest.java
@@ -36,7 +36,7 @@ public class DataFilterBeanFactoryPostProcessorIntegrationTest extends BaseFilte
 	public void postProcessBeanFactory_shouldRegisterFiltersToHbmFiles() {
 		assertEquals(FILTER_REGISTRATION_COUNT, Util.getHibernateFilterRegistrations().size());
 		Set<String> registeredFilters = sessionFactory.getDefinedFilterNames();
-		assertEquals(FILTELTER_REGISTARED_COUNT, registeredFilters.size());
+		assertEquals(FILTER_REGISTARED_COUNT, registeredFilters.size());
 		for (String filterName : testXMlFilters) {
 			assertTrue("Expected filter '" + filterName + "' to be registered in SessionFactory",
 			    registeredFilters.contains(filterName));

--- a/api/src/test/java/org/openmrs/module/datafilter/DataFilterBeanFactoryPostProcessorIntegrationTest.java
+++ b/api/src/test/java/org/openmrs/module/datafilter/DataFilterBeanFactoryPostProcessorIntegrationTest.java
@@ -20,9 +20,11 @@ import org.openmrs.module.datafilter.impl.BaseFilterTest;
 import org.springframework.beans.factory.annotation.Autowired;
 
 public class DataFilterBeanFactoryPostProcessorIntegrationTest extends BaseFilterTest {
-
+	
 	private static final int FILTER_REGISTRATION_COUNT = 20;
-	private static final int FILTELTER_REGISTARED_COUNT = 19;
+	
+	private static final int FILTER_REGISTARED_COUNT = 19;
+	
 	@Autowired
 	private static final String[] testXMlFilters = new String[] { "datafilter_locationFilter1", "datafilter_locationFilter2",
 	        "datafilter_CareSettingFilter" };
@@ -37,8 +39,8 @@ public class DataFilterBeanFactoryPostProcessorIntegrationTest extends BaseFilte
 		assertEquals(FILTELTER_REGISTARED_COUNT, registeredFilters.size());
 		for (String filterName : testXMlFilters) {
 			assertTrue("Expected filter '" + filterName + "' to be registered in SessionFactory",
-					registeredFilters.contains(filterName));
+			    registeredFilters.contains(filterName));
 		}
 	}
-
+	
 }

--- a/api/src/test/java/org/openmrs/module/datafilter/DataFilterBeanFactoryPostProcessorIntegrationTest.java
+++ b/api/src/test/java/org/openmrs/module/datafilter/DataFilterBeanFactoryPostProcessorIntegrationTest.java
@@ -10,6 +10,7 @@
 package org.openmrs.module.datafilter;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.util.Set;
 
@@ -19,7 +20,10 @@ import org.openmrs.module.datafilter.impl.BaseFilterTest;
 import org.springframework.beans.factory.annotation.Autowired;
 
 public class DataFilterBeanFactoryPostProcessorIntegrationTest extends BaseFilterTest {
-	
+
+	private static final int FILTER_REGISTRATION_COUNT = 20;
+	private static final int FILTELTER_REGISTARED_COUNT = 19;
+	@Autowired
 	private static final String[] testXMlFilters = new String[] { "datafilter_locationFilter1", "datafilter_locationFilter2",
 	        "datafilter_CareSettingFilter" };
 	
@@ -28,12 +32,13 @@ public class DataFilterBeanFactoryPostProcessorIntegrationTest extends BaseFilte
 	
 	@Test
 	public void postProcessBeanFactory_shouldRegisterFiltersToHbmFiles() {
-		assertEquals(20, Util.getHibernateFilterRegistrations().size());
+		assertEquals(FILTER_REGISTRATION_COUNT, Util.getHibernateFilterRegistrations().size());
 		Set<String> registeredFilters = sessionFactory.getDefinedFilterNames();
-		assertEquals(19, registeredFilters.size());
+		assertEquals(FILTELTER_REGISTARED_COUNT, registeredFilters.size());
 		for (String filterName : testXMlFilters) {
-			registeredFilters.contains(filterName);
+			assertTrue("Expected filter '" + filterName + "' to be registered in SessionFactory",
+					registeredFilters.contains(filterName));
 		}
 	}
-	
+
 }


### PR DESCRIPTION
As mentioned in https://talk.openmrs.org/t/using-lombok-enums-and-fixing-the-test-suite/48707 the old .contains() method didn`t properly check the testXmlFilters. The proposed implementation should accomplish that.